### PR TITLE
Build changes for GCC-9, MacOS Catalina and new netcdf binary and library installed with Homebrew

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_BUILD_TYPE Release)
 
 # Use GNU GCC on OSX (LLVM clang won't work, see Issues on github, change "gcc-5" accordingly with your current version!)
 if(APPLE)
-	set(CMAKE_C_COMPILER "gcc-5")
+	set(CMAKE_C_COMPILER "gcc-9")
 endif()
 
 # Show all compile warnings
@@ -26,7 +26,9 @@ find_package( PkgConfig REQUIRED )
 pkg_check_modules( Netcdf REQUIRED netcdf )
 
 include_directories(src)
+include_directories(/usr/local/Cellar/netcdf/4.6.3_1/include)
 FILE(GLOB Ncdump-json-src "src/*.c")
+FILE(GLOB Netcdf_LIBRARIES "/usr/local/Cellar/netcdf/4.6.3_1/lib/*.dylib")
 
 #add_executable(ncdump-json src/ncdump.c src/vardata.c src/dumplib.c src/indent.c src/nctime.c src/nciter.c)
 add_executable(ncdump-json ${Ncdump-json-src})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,9 +26,12 @@ find_package( PkgConfig REQUIRED )
 pkg_check_modules( Netcdf REQUIRED netcdf )
 
 include_directories(src)
-include_directories(/usr/local/Cellar/netcdf/4.6.3_1/include)
 FILE(GLOB Ncdump-json-src "src/*.c")
-FILE(GLOB Netcdf_LIBRARIES "/usr/local/Cellar/netcdf/4.6.3_1/lib/*.dylib")
+
+if(APPLE)
+	include_directories(/usr/local/Cellar/netcdf/4.6.3_1/include)
+	FILE(GLOB Netcdf_LIBRARIES "/usr/local/Cellar/netcdf/4.6.3_1/lib/*.dylib")
+endif()
 
 #add_executable(ncdump-json src/ncdump.c src/vardata.c src/dumplib.c src/indent.c src/nctime.c src/nciter.c)
 add_executable(ncdump-json ${Ncdump-json-src})

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ It behaves exactly like the original ncdump if you omit the command-line option 
 
 Installation:
 
-* Download latest tag, unzip. 
-* Install cmake and libnetcdf-dev
+* Download latest tag, unzip.
+* Install cmake, libnetcdf-dev and pkg-config
 * cd ncdump-json directory
 * $cmake .
 * $make (you might get some warnings, it is ok).


### PR DESCRIPTION
Hello @jllodra,

Thanks for `ncdump-json`, really appreciated it!

I had to install it on macOS Catalina and had some problems so here are some improvements that fixed it for me. 

Sorry I didn't have enough time to parameterize everything and some Linux or Windows to test it too.
I believe that the Linux package is really similar and for Windows using something like `Chocolatey` to install the latest version of `netcdf` should do the job.

> **NOTE:** for the dynamic libs in cmake for Linux you should use **'*.so'** and for Windows **'*.dll'** files

Flow...

Since the brew package `homebrew/science/netcdf` is no longer available you have to install the new package with comes with the libraries and the included header files.

```shell
brew install netcdf
```
The `netcdf` package also installs the latest GCC (v9) which should be enough
Brew standard install location is `/usr/local/Cellar`

Also, you need the `pkg-config` installed which is not listed in the installation steps.

Putting this here so someone checking it can use it...
```shell
1. $ brew install netcdf
2. $ brew install pkg-config
3. $ brew install cmake
```





  