### PR TITLE
Avoid using '#' in float format specifier for float attributes for valid JSON

### DIFF
--- a/src/ncdump.c
+++ b/src/ncdump.c
@@ -419,7 +419,14 @@ pr_att_valgs(
         ff = ((float *) vals)[iel];
         if (isfinite(ff)) {
           int res;
-          res = snprintf(gps, PRIM_LEN, float_att_fmt, ff);
+          const char* fmt;
+          /* Avoid trailing '.' with # flag in format specifier for JSON */
+          if (!is_json) {
+            fmt = float_att_fmt;
+          } else {
+            fmt = float_var_fmt;
+          }
+          res = snprintf(gps, PRIM_LEN, fmt, ff);
           assert(res < PRIM_LEN);
           if (!is_json) {
             tztrim(gps); /* trim trailing 0's after '.' */
@@ -444,7 +451,14 @@ pr_att_valgs(
         dd = ((double *) vals)[iel];
         if (isfinite(dd)) {
           int res;
-          res = snprintf(gps, PRIM_LEN, double_att_fmt, dd);
+          const char* fmt;
+          /* Avoid trailing '.' with # flag in format specifier for JSON */
+          if (!is_json) {
+            fmt = double_att_fmt;
+          } else {
+            fmt = double_var_fmt;
+          }
+          res = snprintf(gps, PRIM_LEN, fmt, dd);
           assert(res < PRIM_LEN);
           if (!is_json) {
             tztrim(gps); /* trim trailing 0's after '.' */


### PR DESCRIPTION
Recently we encountered a data set that produced output values on variable attribute floats with trailing decimals, for example:

```
"resolution":1000000.,
```

This not valid JSON and broke parsing. 

I was able to recreate the issue with the test data set in the repo, under tests:

```
../ncdump-json -j -h -p 1 ./sresa1b_ncar_ccsm3-example.nc
```

Produces this in the output:
```
"missing_value":1.e+20
```

~This PR fixes the problem by detecting the case where a `.` is followed by a non digit and adds a single 0.~

Now fixed by using the standard variable format specifier which does not have '#'

